### PR TITLE
修正 composer develop 建置錯誤問題

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     },
     "scripts": {
         "post-root-package-install": [
-            "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+            "php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
+            "php -r \"file_exists('resources/assets/images') || mkdir('resources/assets/images');\""
         ],
         "post-create-project-cmd": [
             "php artisan key:generate"
@@ -56,10 +57,10 @@
         "develop": [
             "composer update",
             "yarn install",
+            "@build",
             "php artisan ide-helper:generate",
             "php artisan ide-helper:meta",
             "npm run dev",
-            "@build",
             "@build-container"
         ],
         "production": [


### PR DESCRIPTION
專案在 git clone 下來後，執行 composer develop，無法正常建置開發環境，此 PR 為修正此錯誤，便於後續人員可以順利完成專案初使化的建置。